### PR TITLE
Fix printing of Arch E & D paper sizes [#166192812]

### DIFF
--- a/app/assets/javascripts/pdfjs_viewer/viewer.js
+++ b/app/assets/javascripts/pdfjs_viewer/viewer.js
@@ -7133,10 +7133,18 @@ var pdfjsWebLibs;
    var activeService = null;
    function renderPage(activeServiceOnEntry, pdfDocument, pageNumber, size) {
     var scratchCanvas = activeService.scratchCanvas;
+
+    var MAX_CANVAS_AREA = 268435456; // Per https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas#Maximum_canvas_size
     var PRINT_RESOLUTION = 600;
-    var PRINT_UNITS = PRINT_RESOLUTION / 72.0;
-    scratchCanvas.width = Math.floor(size.width * PRINT_UNITS);
-    scratchCanvas.height = Math.floor(size.height * PRINT_UNITS);
+    do {
+      var PRINT_UNITS = PRINT_RESOLUTION / 72.0;
+      var canvasWidth = Math.floor(size.width * PRINT_UNITS);
+      var canvasHeight = Math.floor(size.height * PRINT_UNITS);
+      var canvasArea = canvasWidth * canvasHeight;
+    } while (canvasArea > MAX_CANVAS_AREA && (PRINT_RESOLUTION -= 1) > 0);
+
+    scratchCanvas.width = canvasWidth;
+    scratchCanvas.height = canvasHeight;
     var width = Math.floor(size.width * CSS_UNITS) + 'px';
     var height = Math.floor(size.height * CSS_UNITS) + 'px';
     var ctx = scratchCanvas.getContext('2d');


### PR DESCRIPTION
PDF.js was failing when the user printed with the Arch E or Arch D paper size.  This happened because PDF.js created a `canvas` element that exceeded Chrome's maximum area for a `canvas`.

Fixing this by defaulting to 600 DPI but dynamically choosing a lower DPI if 600 would cause PDF.js to exceed Chrome's max area.

After merging this, we'll need to update https://github.com/officespacesoftware/huddle/blob/master/Gemfile.lock